### PR TITLE
fix: update GitHub Repository button link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
           </a>
           <a
             className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-auto"
-            href="https://github.com/anthropics/claude-code"
+            href="https://github.com/PabloVillaplanaDatacor/pennant-mill-manager-ai"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Updates the GitHub Repository button on the homepage to link to this repository instead of the Claude Code repository.

Closes #3

Generated with [Claude Code](https://claude.ai/code)