### PR TITLE
fix: remove 'BY JUAN PABLO' from page title

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
         />
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
           <h1 className="max-w-xl text-4xl font-semibold leading-tight tracking-tight text-black dark:text-zinc-50">
-            How to Claude save my life BY JUAN PABLO
+            How to Claude save my life
           </h1>
           <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
             A presentation demonstrating the capabilities and best practices for using Claude Code in our development workflow.


### PR DESCRIPTION
Removes "BY JUAN PABLO" from the main page title heading.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)